### PR TITLE
Unify the constant of residual decomposition

### DIFF
--- a/pystoned/StoNED.py
+++ b/pystoned/StoNED.py
@@ -4,7 +4,7 @@ import numpy as np
 import math
 import scipy.stats as stats
 import scipy.optimize as opt
-from .constant import CET_ADDI, CET_MULT, FUN_PROD, FUN_COST, RTS_CRS, RTS_VRS
+from .constant import CET_ADDI, CET_MULT, FUN_PROD, FUN_COST, RTS_VRS, RED_MOM, RED_QLE, RED_KDE
 
 
 class StoNED(CNLS.CNLS):
@@ -24,27 +24,27 @@ class StoNED(CNLS.CNLS):
         """
         super().__init__(y, x, z, cet, fun, rts)
 
-    def get_unconditional_expected_inefficiency(self, method='MOM'):
-        # method  = "MOM" : Method of moments
-        #         = "QLE" : Quassi-likelihood estimation
-        #         = "KDE" : kernel deconvolution estimation
+    def get_unconditional_expected_inefficiency(self, method=RED_MOM):
+        # method  = RED_MOM : Method of moments
+        #         = RED_QLE : Quassi-likelihood estimation
+        #         = RED_KDE : Kernel deconvolution estimation
         if self.optimization_status == 0:
             print("Model isn't optimized. Use optimize() method to estimate the model.")
             return False
-        if method == "MOM":
+        if method == RED_MOM:
             self.__method_of_moment(self.get_residual())
-        elif method == "QLE":
+        elif method == RED_QLE:
             self.__quassi_likelihood(self.get_residual())
-        elif method == "KDE":
+        elif method == RED_KDE:
             self.__gaussian_kernel_estimation(self.get_residual())
         else:
             # TODO(error/warning handling): Raise error while undefined method
             return False
         return self.mu
 
-    def get_technical_inefficiency(self, method='MOM'):
-        # method  = "MOM" : Method of moments
-        #         = "QLE" : Quassi-likelihood estimation
+    def get_technical_inefficiency(self, method=RED_MOM):
+        # method  = RED_MOM : Method of moments
+        #         = RED_QLE : Quassi-likelihood estimation
 
         # calculate sigma_u, sigma_v, mu, and epsilon value
         if self.optimization_status == 0:

--- a/pystoned/constant.py
+++ b/pystoned/constant.py
@@ -30,6 +30,16 @@ ORIENT_Categories = {
     ORIENT_OO: "Output orientation"
 }
 
+# Residual decomposition
+RED_MOM = "MOM"
+RED_QLE = "QLE"
+RED_KDE = "KDE"
+RED_Categories = {
+    RED_MOM: "Method of moments",
+    RED_QLE: "Quassi-likelihood estimation",
+    RED_KDE: "Kernel deconvolution estimation"
+}
+
 # Optimization
 OPT_LOCAL = "local"
 OPT_DEFAULT = None


### PR DESCRIPTION
In the review of the project, I found there is a category left in constant.
* This pr provides the unification of residual decomposition

Here is a example for the use of the constant
```python
from pystoned import StoNED
from pystoned.dataset import load_Finnish_electricity_firm
from pystoned.constant import CET_ADDI, RTS_VRS, FUN_PROD, RED_MOM
data = load_Finnish_electricity_firm(y_select=['Energy'], x_select=['OPEX', 'CAPEX'])

# build and optimize
instance = StoNED.StoNED(y=data.y, x=data.x, cet=CET_ADDI, fun=FUN_PROD, rts=RTS_VRS)
instance.optimize('youraddres@site.com')
instance.display_residual()

print(instance.get_technical_inefficiency(method=RED_MOM))
```