### PR TITLE
fix: Add missing additive 

### DIFF
--- a/pystoned/CNLS.py
+++ b/pystoned/CNLS.py
@@ -244,35 +244,42 @@ class CNLS:
     def display_status(self):
         """Display the status of problem"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         print(self.display_status)
 
     def display_alpha(self):
         """Display alpha value"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         if self.rts == RTS_CRS:
-            raise Exception("Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
+            raise Exception(
+                "Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
         self.__model__.alpha.display()
 
     def display_beta(self):
         """Display beta value"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         self.__model__.beta.display()
 
     def display_lamda(self):
         """Display lamda value"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         if type(self.z) == type(None):
-            raise Exception("Estimated coefficient (lambda) cannot be retrieved due to no z variable included in the model.")
+            raise Exception(
+                "Estimated coefficient (lambda) cannot be retrieved due to no z variable included in the model.")
         self.__model__.lamda.display()
 
     def display_residual(self):
         """Dispaly residual value"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         self.__model__.epsilon.display()
 
     def get_status(self):
@@ -282,16 +289,19 @@ class CNLS:
     def get_alpha(self):
         """Return alpha value by array"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         if self.rts == RTS_CRS:
-            raise Exception("Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
+            raise Exception(
+                "Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
         alpha = list(self.__model__.alpha[:].value)
         return np.asarray(alpha)
 
     def get_beta(self):
         """Return beta value by array"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         beta = np.asarray([i + tuple([j]) for i, j in zip(list(self.__model__.beta),
                                                           list(self.__model__.beta[:, :].value))])
         beta = pd.DataFrame(beta, columns=['Name', 'Key', 'Value'])
@@ -301,23 +311,27 @@ class CNLS:
     def get_residual(self):
         """Return residual value by array"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         residual = list(self.__model__.epsilon[:].value)
         return np.asarray(residual)
 
     def get_lamda(self):
         """Return beta value by array"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         if type(self.z) == type(None):
-            raise Exception("Estimated coefficient (lambda) cannot be retrieved due to no z variable included in the model.")
+            raise Exception(
+                "Estimated coefficient (lambda) cannot be retrieved due to no z variable included in the model.")
         lamda = list(self.__model__.lamda[:].value)
         return np.asarray(lamda)
 
     def get_frontier(self):
         """Return estimated frontier value by array"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         if self.cet == CET_MULT and type(self.z) == type(None):
             frontier = np.asarray(list(self.__model__.frontier[:].value)) + 1
         elif self.cet == CET_MULT and type(self.z) != type(None):
@@ -330,11 +344,13 @@ class CNLS:
     def get_adjusted_residual(self):
         """Return the shifted residuals(epsilon) tern by CCNLS"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         return self.get_residual() - np.amax(self.get_residual())
 
     def get_adjusted_alpha(self):
         """Return the shifted constatnt(alpha) term by CCNLS"""
         if self.optimization_status == 0:
-            raise Exception("Model isn't optimized. Use optimize() method to estimate the model.")
+            raise Exception(
+                "Model isn't optimized. Use optimize() method to estimate the model.")
         return self.get_alpha() + np.amax(self.get_residual())

--- a/pystoned/CNLSG.py
+++ b/pystoned/CNLSG.py
@@ -5,6 +5,7 @@ from .utils import CNLSG1, CNLSG2, CNLSZG1, CNLSZG2, sweet, tools
 from .constant import CET_ADDI, CET_MULT, FUN_PROD, FUN_COST, OPT_DEFAULT, RTS_CRS, RTS_VRS, OPT_DEFAULT, OPT_LOCAL
 import time
 
+
 class CNLSG:
     """Convex Nonparametric Least Square (CNLS) with Genetic algorithm
     """
@@ -110,6 +111,13 @@ class CNLSG:
                         elif self.fun == FUN_COST:
                             self.active2[i, j] = - alpha[i] - np.sum(beta[i, :] * x[i, :]) + \
                                 alpha[j] + np.sum(beta[j, :] * x[i, :])
+                    if self.rts == RTS_CRS:
+                        if self.fun == FUN_PROD:
+                            self.active2[i, j] = np.sum(beta[i, :] * x[i, :]) \
+                                - np.sum(beta[j, :] * x[i, :])
+                        elif self.fun == FUN_COST:
+                            self.active2[i, j] = - np.sum(beta[i, :] * x[i, :]) \
+                                + np.sum(beta[j, :] * x[i, :])
                 if self.cet == CET_MULT:
                     if self.rts == RTS_VRS:
                         if self.fun == FUN_PROD:

--- a/pystoned/CQER.py
+++ b/pystoned/CQER.py
@@ -156,8 +156,19 @@ class CQR:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                if type(self.z) != type(None):
+                    def regression_rule(model, i):
+                        return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                            + sum(model.lamda[k] * self.z[i][k]
+                                  for k in model.K) + model.epsilon[i]
+
+                    return regression_rule
+
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                        + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
             if type(self.z) != type(None):
@@ -218,8 +229,16 @@ class CQR:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def afriat_rule(model, i, h):
+                    if i == h:
+                        return Constraint.Skip
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[h, j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/CQERG.py
+++ b/pystoned/CQERG.py
@@ -113,6 +113,13 @@ class CQRG:
                         elif self.fun == FUN_COST:
                             self.active2[i, j] = - alpha[i] - np.sum(beta[i, :] * x[i, :]) + \
                                 alpha[j] + np.sum(beta[j, :] * x[i, :])
+                    if self.rts == RTS_CRS:
+                        if self.fun == FUN_PROD:
+                            self.active2[i, j] = np.sum(beta[i, :] * x[i, :]) \
+                                - np.sum(beta[j, :] * x[i, :])
+                        elif self.fun == FUN_COST:
+                            self.active2[i, j] = - np.sum(beta[i, :] * x[i, :]) \
+                                + np.sum(beta[j, :] * x[i, :])
                 if self.cet == CET_MULT:
                     if self.rts == RTS_VRS:
                         if self.fun == FUN_PROD:
@@ -402,6 +409,13 @@ class CERG:
                         elif self.fun == FUN_COST:
                             self.Active2[i, j] = - alpha[i] - np.sum(beta[i, :] * x[i, :]) + \
                                 alpha[j] + np.sum(beta[j, :] * x[i, :])
+                    if self.rts == RTS_VRS:
+                        if self.fun == FUN_PROD:
+                            self.Active2[i, j] = np.sum(beta[i, :] * x[i, :]) \
+                                - np.sum(beta[j, :] * x[i, :])
+                        elif self.fun == FUN_COST:
+                            self.Active2[i, j] = - np.sum(beta[i, :] * x[i, :]) \
+                                + np.sum(beta[j, :] * x[i, :])
                 if self.cet == CET_MULT:
                     if self.rts == RTS_VRS:
                         if self.fun == FUN_PROD:

--- a/pystoned/ICNLS.py
+++ b/pystoned/ICNLS.py
@@ -52,8 +52,18 @@ class ICNLS(CNLS.CNLS):
                 return afriat_rule
 
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i, h):
+                    if i == h or self.__pmatrix[i][h] == 0:
+                        return Constraint.Skip
+                    return __operator(
+                        self.__pmatrix[i][i] * sum(
+                            model.beta[i, j] * self.x[i][j] for j in model.J),
+                        self.__pmatrix[i][h] * sum(
+                            model.beta[h, j] * self.x[i][j] for j in model.J)
+                    )
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/StoNED.py
+++ b/pystoned/StoNED.py
@@ -16,11 +16,12 @@ class StoNED:
         """
         self.model = model
         self.x = model.x
-        
+
         # If the model is a directional distance based, set cet to CET_ADDI
         if hasattr(self.model, 'gx'):
             self.model.cet = CET_ADDI
-            self.y = np.diag(np.tensordot(self.model.y, self.model.get_gamma(),axes=([1],[1])))
+            self.y = np.diag(np.tensordot(
+                self.model.y, self.model.get_gamma(), axes=([1], [1])))
         else:
             self.y = self.model.y
 
@@ -223,7 +224,7 @@ class StoNED:
             if self.model.cet == CET_ADDI:
                 return (self.y - self.model.get_residual()) + self.sigma_u * math.sqrt(2 / math.pi)
             elif self.model.cet == CET_MULT:
-                return  (self.y / np.exp(self.model.get_residual())) * np.exp(self.sigma_u * math.sqrt(2 / math.pi))
+                return (self.y / np.exp(self.model.get_residual())) * np.exp(self.sigma_u * math.sqrt(2 / math.pi))
         elif self.model.fun == FUN_COST:
             if self.model.cet == CET_ADDI:
                 return (self.y - self.model.get_residual()) - self.sigma_u * math.sqrt(2 / math.pi)

--- a/pystoned/plot.py
+++ b/pystoned/plot.py
@@ -5,7 +5,8 @@ import numpy as np
 from .utils import interpolation
 from .constant import FUN_PROD, FUN_COST, RED_MOM
 
-def plot2d(model, x_select=0, label_name="estimated function", fig_name=None, method= RED_MOM ):
+
+def plot2d(model, x_select=0, label_name="estimated function", fig_name=None, method=RED_MOM):
     """Plot 2d estimated function/frontier
 
     Args:
@@ -28,7 +29,7 @@ def plot2d(model, x_select=0, label_name="estimated function", fig_name=None, me
 
     # sort
     data = data[np.argsort(data[:, 0])].T
-    
+
     x, y, f = data[0], data[1], data[2]
 
     # create figure and axes objects
@@ -56,7 +57,8 @@ def plot2d(model, x_select=0, label_name="estimated function", fig_name=None, me
     else:
         plt.savefig(fig_name)
 
-def plot3d(model, x_select_1=0, x_select_2=1,fig_name=None, line_transparent=False, pane_transparent=False):
+
+def plot3d(model, x_select_1=0, x_select_2=1, fig_name=None, line_transparent=False, pane_transparent=False):
     """Plot 3d estimated function/frontier
 
     Args:
@@ -81,16 +83,16 @@ def plot3d(model, x_select_1=0, x_select_2=1,fig_name=None, line_transparent=Fal
     dp = ax.scatter(x[x_select_1], x[x_select_2], y, marker='.', s=10)
 
     # Revise the Z-axis left side
-    tmp_planes = ax.zaxis._PLANES 
-    ax.zaxis._PLANES = (tmp_planes[2], tmp_planes[3], 
-                        tmp_planes[0], tmp_planes[1], 
+    tmp_planes = ax.zaxis._PLANES
+    ax.zaxis._PLANES = (tmp_planes[2], tmp_planes[3],
+                        tmp_planes[0], tmp_planes[1],
                         tmp_planes[4], tmp_planes[5])
 
     # make the grid lines transparent
     if line_transparent == False:
-        ax.xaxis._axinfo["grid"]['color'] =  (1,1,1,0)
-        ax.yaxis._axinfo["grid"]['color'] =  (1,1,1,0)
-        ax.zaxis._axinfo["grid"]['color'] =  (1,1,1,0)
+        ax.xaxis._axinfo["grid"]['color'] = (1, 1, 1, 0)
+        ax.yaxis._axinfo["grid"]['color'] = (1, 1, 1, 0)
+        ax.zaxis._axinfo["grid"]['color'] = (1, 1, 1, 0)
 
     # make the panes transparent
     if pane_transparent != False:
@@ -98,24 +100,25 @@ def plot3d(model, x_select_1=0, x_select_2=1,fig_name=None, line_transparent=Fal
         ax.yaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
         ax.zaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
 
-    xlin1 = np.linspace(min(x[x_select_1]),max(x[x_select_1]),30)
-    xlin2 = np.linspace(min(x[x_select_2]),max(x[x_select_2]),30)
-    XX, YY = np.meshgrid(xlin1,xlin2)
+    xlin1 = np.linspace(min(x[x_select_1]), max(x[x_select_1]), 30)
+    xlin2 = np.linspace(min(x[x_select_2]), max(x[x_select_2]), 30)
+    XX, YY = np.meshgrid(xlin1, xlin2)
 
-    ZZ = np.zeros((len(XX),len(XX)))
+    ZZ = np.zeros((len(XX), len(XX)))
     for i in range(len(XX)):
         for j in range(len(XX)):
-            ZZ[i,j] = interpolation.interpolation(alpha, beta,
-                                                    x=np.array([XX[i,j],YY[i,j]],ndmin=2),
-                                                    fun=model.fun)
+            ZZ[i, j] = interpolation.interpolation(alpha, beta,
+                                                   x=np.array(
+                                                       [XX[i, j], YY[i, j]], ndmin=2),
+                                                   fun=model.fun)
 
-    fl = ax.plot_surface(XX, YY, ZZ, rstride=1, cstride=1, cmap='viridis', 
-                                    edgecolor='none', alpha=0.5)
+    fl = ax.plot_surface(XX, YY, ZZ, rstride=1, cstride=1, cmap='viridis',
+                         edgecolor='none', alpha=0.5)
 
     # add x, y, z label
     ax.set_xlabel("Input $x1$")
     ax.set_ylabel("Input $x2$")
-    ax.set_zlabel("Output $y$", rotation=0) 
+    ax.set_zlabel("Output $y$", rotation=0)
 
     if fig_name == None:
         plt.show()

--- a/pystoned/utils/CNLSG1.py
+++ b/pystoned/utils/CNLSG1.py
@@ -107,9 +107,11 @@ class CNLSG1:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                        + model.epsilon[i]
 
+                return regression_rule
         elif self.cet == CET_MULT:
 
             def regression_rule(model, i):
@@ -162,8 +164,14 @@ class CNLSG1:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                          for j in model.J),
+                                      sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                                          for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -210,8 +218,18 @@ class CNLSG1:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CNLSG2.py
+++ b/pystoned/utils/CNLSG2.py
@@ -114,8 +114,12 @@ class CNLSG2:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) + \
+                        model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -168,8 +172,15 @@ class CNLSG2:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -216,7 +227,18 @@ class CNLSG2:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
+
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
                 return False
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
@@ -269,8 +291,16 @@ class CNLSG2:
 
                 return sweet_rule2
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule2(model, i, h):
+                    if self.active[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+                return sweet_rule2
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CNLSG2.py
+++ b/pystoned/utils/CNLSG2.py
@@ -239,7 +239,6 @@ class CNLSG2:
                     return Constraint.Skip
 
                 return sweet_rule
-                return False
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CNLSZG1.py
+++ b/pystoned/utils/CNLSZG1.py
@@ -118,8 +118,13 @@ class CNLSZG1:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                        + sum(model.lamda[k] * self.z[i][k]
+                              for k in model.K) + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -172,8 +177,14 @@ class CNLSZG1:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -220,8 +231,18 @@ class CNLSZG1:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CNLSZG2.py
+++ b/pystoned/utils/CNLSZG2.py
@@ -124,8 +124,13 @@ class CNLSZG2:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) + \
+                        sum(model.lamda[k] * self.z[i][k]
+                            for k in model.K) + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -179,8 +184,15 @@ class CNLSZG2:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -227,8 +239,17 @@ class CNLSZG2:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -280,8 +301,17 @@ class CNLSZG2:
 
                 return sweet_rule2
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def sweet_rule2(model, i, h):
+                    if self.active[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CQERG1.py
+++ b/pystoned/utils/CQERG1.py
@@ -125,8 +125,11 @@ class CQRG1:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                        + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -180,8 +183,15 @@ class CQRG1:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -228,8 +238,17 @@ class CQRG1:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CQERG2.py
+++ b/pystoned/utils/CQERG2.py
@@ -132,8 +132,11 @@ class CQRG2:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) + \
+                        model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -186,8 +189,15 @@ class CQRG2:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -234,8 +244,18 @@ class CQRG2:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -287,8 +307,18 @@ class CQRG2:
 
                 return sweet_rule2
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def sweet_rule2(model, i, h):
+                    if self.active[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule2
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CQERZG1.py
+++ b/pystoned/utils/CQERZG1.py
@@ -136,8 +136,13 @@ class CQRZG1:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) \
+                        + sum(model.lamda[k] * self.z[i][k]
+                              for k in model.K) + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -191,8 +196,15 @@ class CQRZG1:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -239,8 +251,17 @@ class CQRZG1:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(sum(model.beta[i, j] * self.x[i][j]
+                                              for j in model.J),
+                                          sum(model.beta[h, j] * self.x[i][j]
+                                              for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/CQERZG2.py
+++ b/pystoned/utils/CQERZG2.py
@@ -142,8 +142,12 @@ class CQRZG2:
 
                 return regression_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def regression_rule(model, i):
+                    return self.y[i] == sum(model.beta[i, j] * self.x[i][j] for j in model.J) + \
+                        sum(model.lamda[k] * self.z[i][k]
+                            for k in model.K) + model.epsilon[i]
+
+                return regression_rule
 
         elif self.cet == CET_MULT:
 
@@ -197,8 +201,14 @@ class CQRZG2:
 
                 return afriat_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def afriat_rule(model, i):
+                    return __operator(
+                        sum(model.beta[i, j] * self.x[i][j]
+                            for j in model.J),
+                        sum(model.beta[self.__model__.I.nextw(i), j] * self.x[i][j]
+                            for j in model.J))
+
+                return afriat_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -245,8 +255,17 @@ class CQRZG2:
 
                 return sweet_rule
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule(model, i, h):
+                    if self.cutactive[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(model.alpha[i] + sum(model.beta[i, j] * self.x[i][j]
+                                                               for j in model.J),
+                                          model.alpha[h] + sum(model.beta[h, j] * self.x[i][j]
+                                                               for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 
@@ -298,8 +317,17 @@ class CQRZG2:
 
                 return sweet_rule2
             elif self.rts == RTS_CRS:
-                # TODO(warning handling): replace with model requested not exist
-                return False
+                def sweet_rule2(model, i, h):
+                    if self.active[i, h]:
+                        if i == h:
+                            return Constraint.Skip
+                        return __operator(model.alpha[i] + sum(model.beta[i, j] * self.x[i][j]
+                                                               for j in model.J),
+                                          model.alpha[h] + sum(model.beta[h, j] * self.x[i][j]
+                                                               for j in model.J))
+                    return Constraint.Skip
+
+                return sweet_rule2
         elif self.cet == CET_MULT:
             if self.rts == RTS_VRS:
 

--- a/pystoned/utils/interpolation.py
+++ b/pystoned/utils/interpolation.py
@@ -20,10 +20,10 @@ def interpolation(alpha, beta, x, fun=FUN_PROD):
 
     if fun == FUN_PROD:
         def fun_est(x):
-                return min(alpha + np.sum(beta[:,0:d] * np.tile(x,(len(beta[:,0:d]), 1)), axis=1))
+            return min(alpha + np.sum(beta[:, 0:d] * np.tile(x, (len(beta[:, 0:d]), 1)), axis=1))
     elif fun == FUN_COST:
         def fun_est(x):
-                return max(alpha + np.sum(beta[:,0:d] * np.tile(x,(len(beta[:,0:d]), 1)), axis=1))
+            return max(alpha + np.sum(beta[:, 0:d] * np.tile(x, (len(beta[:, 0:d]), 1)), axis=1))
 
     yhat = np.zeros((n, 1))
     for i in range(n):

--- a/pystoned/utils/tools.py
+++ b/pystoned/utils/tools.py
@@ -31,7 +31,8 @@ def optimize_model(model, email, cet, solver=OPT_DEFAULT):
             print("Estimating the additive model locally with mosek solver")
             return solver.solve(model, tee=True), 1
         elif cet == CET_MULT:
-            raise ValueError("Please specify the solver for optimizing multiplicative model locally.")
+            raise ValueError(
+                "Please specify the solver for optimizing multiplicative model locally.")
     else:
         if solver is OPT_DEFAULT and cet is CET_ADDI:
             solver = "mosek"
@@ -41,6 +42,7 @@ def optimize_model(model, email, cet, solver=OPT_DEFAULT):
             print("Estimating the multiplicative model remotely with knitro solver")
         remote_solver = SolverManagerFactory('neos')
         return remote_solver.solve(model, tee=True, opt=solver), 1
+
 
 def trans_list(li):
     if type(li) == list:


### PR DESCRIPTION
Here are the implementation of all missing additive CRS models:
* CNLSG and its submodules
* CQERG and its submodules
* CQER
* ICNLS

All the afriat and regression rule are equal to their VRS version without intercept(Alpha).
I'm curious about the situation with z-variable.
The frontier without intercept is still lifted by z-variable and its coefficient.
I wonder if this situation can be called constant return to scale?

Thanks for further informations.