### PR TITLE
fix(DEA): Fix reference set initialization

### DIFF
--- a/pystoned/DEA.py
+++ b/pystoned/DEA.py
@@ -348,10 +348,10 @@ class DUAL(DEA):
         tools.assert_optimized(self.optimization_status)
         self.__model__.nu.display()
 
-    # Omega only exists in VRS model. So, print a similar info like: https://github.com/ds2010/pyStoNED/blob/dfdddd9e143933880ac1444dfd895157f8277122/pystoned/utils/tools.py#L202
     def display_omega(self):
          """Display omega value"""
          tools.assert_optimized(self.optimization_status)
+         tools.assert_various_return_to_scale_omega(self.rts)
          self.__model__.omega.display()       
 
     def get_mu(self):
@@ -376,6 +376,7 @@ class DUAL(DEA):
     def get_omega(self):
         """Return omega value by array"""
         tools.assert_optimized(self.optimization_status)
+        tools.assert_various_return_to_scale_omega(self.rts)
         omega = list(self.__model__.omega[:].value)
         return np.asarray(omega)
 

--- a/pystoned/DEA.py
+++ b/pystoned/DEA.py
@@ -43,7 +43,7 @@ class DEA:
 
         # Initialize variable
         self.__model__.theta = Var(self.__model__.I, doc='efficiency')
-        self.__model__.lamda = Var(self.__model__.I, self.__model__.I, bounds=(
+        self.__model__.lamda = Var(self.__model__.I, self.__model__.R, bounds=(
             0.0, None), doc='intensity variables')
 
         # Setup the objective function and constraints
@@ -168,13 +168,14 @@ class DDF(DEA):
             y, x, b, gy, gx, gb)
         self.rts = rts
 
-        self.__reference = False
 
         if type(yref) != type(None):
-            self.__reference = True
             self.yref, self.xref, self.bref = tools.assert_valid_reference_data_with_bad_outputs(
                 self.y, self.x, self.b, yref, xref, bref)
-            self.__model__.R = Set(initialize=range(len(self.yref)))
+        else:
+            self.yref, self.xref, self.bref = self.y, self.x, self.b
+        
+        self.__model__.R = Set(initialize=range(len(self.yref)))
 
         # Initialize sets
         self.__model__.I = Set(initialize=range(len(self.y)))
@@ -186,12 +187,9 @@ class DDF(DEA):
         # Initialize variable
         self.__model__.theta = Var(
             self.__model__.I, doc='directional distance')
-        if self.__reference:
-            self.__model__.lamda = Var(self.__model__.I, self.__model__.R, bounds=(
-                0.0, None), doc='intensity variables')
-        else:
-            self.__model__.lamda = Var(self.__model__.I, self.__model__.I, bounds=(
-                0.0, None), doc='intensity variables')
+
+        self.__model__.lamda = Var(self.__model__.I, self.__model__.R, bounds=(
+            0.0, None), doc='intensity variables')
 
         # Setup the objective function and constraints
         self.__model__.objective = Objective(
@@ -215,47 +213,26 @@ class DDF(DEA):
 
     def __input_rule(self):
         """Return the proper input constraint"""
-        if self.__reference == False:
-            def input_rule(model, o, j):
-                return self.x[o][j] - model.theta[o]*self.gx[j] >= sum(model.lamda[o, i] * self.x[i][j] for i in model.I)
-            return input_rule
-        else:
-            def input_rule(model, o, j):
-                return self.x[o][j] - model.theta[o]*self.gx[j] >= sum(model.lamda[o, r] * self.xref[r][j] for r in model.R)
-            return input_rule
+        def input_rule(model, o, j):
+            return self.x[o][j] - model.theta[o]*self.gx[j] >= sum(model.lamda[o, r] * self.xref[r][j] for r in model.R)
+        return input_rule
 
     def __output_rule(self):
         """Return the proper output constraint"""
-        if self.__reference == False:
-            def output_rule(model, o, k):
-                return self.y[o][k] + model.theta[o]*self.gy[k] <= sum(model.lamda[o, i] * self.y[i][k] for i in model.I)
-            return output_rule
-        else:
-            def output_rule(model, o, k):
-                return self.y[o][k] + model.theta[o]*self.gy[k] <= sum(model.lamda[o, r] * self.yref[r][k] for r in model.R)
-            return output_rule
+        def output_rule(model, o, k):
+            return self.y[o][k] + model.theta[o]*self.gy[k] <= sum(model.lamda[o, r] * self.yref[r][k] for r in model.R)
+        return output_rule
 
     def __undesirable_output_rule(self):
         """Return the proper undesirable output constraint"""
-        if self.__reference == False:
-            def undesirable_output_rule(model, o, l):
-                return self.b[o][l] - model.theta[o]*self.gb[l] == sum(model.lamda[o, i] * self.b[i][l] for i in model.I)
-            return undesirable_output_rule
-        else:
-            def undesirable_output_rule(model, o, l):
-                return self.b[o][l] + model.theta[o]*self.gb[l] == sum(model.lamda[o, r] * self.bref[r][l] for r in model.R)
-            return undesirable_output_rule
+        def undesirable_output_rule(model, o, l):
+            return self.b[o][l] + model.theta[o]*self.gb[l] == sum(model.lamda[o, r] * self.bref[r][l] for r in model.R)
+        return undesirable_output_rule
 
     def __vrs_rule(self):
-        if self.__reference == False:
-            def vrs_rule(model, o):
-                return sum(model.lamda[o, i] for i in model.I) == 1
-            return vrs_rule
-        else:
             def vrs_rule(model, o):
                 return sum(model.lamda[o, r] for r in model.R) == 1
             return vrs_rule
-
 
 class DUAL(DEA):
     def __init__(self, y, x, orient, rts, yref=None, xref=None):

--- a/pystoned/utils/tools.py
+++ b/pystoned/utils/tools.py
@@ -85,7 +85,6 @@ def assert_valid_basic_data(y, x, z=None):
         raise ValueError(
             "The multidimensional output data is supported by direciontal based models.")
 
-
     if y_shape[0] != x_shape[0]:
         raise ValueError(
             "Number of DMUs must be the same in x and y.")
@@ -116,6 +115,7 @@ def assert_valid_mupltiple_y_data(y, x):
             "Number of DMUs must be the same in x and y.")
     return y, x
 
+
 def assert_valid_reference_data(y, x, yref, xref):
     yref = trans_list(yref)
     xref = trans_list(xref)
@@ -137,12 +137,13 @@ def assert_valid_reference_data(y, x, yref, xref):
             "Number of inputs must be the same in x and xref.")
     return yref, xref
 
+
 def assert_valid_reference_data_with_bad_outputs(y, x, b, yref, xref, bref):
     yref, xref = assert_valid_reference_data(y, x, yref, xref)
-    
-    if type(b) != type(None):
+
+    if type(b) == type(None):
         return yref, xref, None
-    
+
     bref = to_2d_list(bref)
     bref_shape = asarray(bref).shape
 
@@ -152,8 +153,9 @@ def assert_valid_reference_data_with_bad_outputs(y, x, b, yref, xref, bref):
     if bref_shape[1] != asarray(b).shape[1]:
         raise ValueError(
             "Number of undesirable outputs  must be the same in b and bref.")
-    
+
     return yref, xref, bref
+
 
 def assert_valid_direciontal_data(y, x, b=None, gy=[1], gx=[1], gb=None):
     y = trans_list(y)
@@ -209,6 +211,12 @@ def assert_undesirable_output(b):
     if type(b) == type(None):
         raise Exception(
             "Estimated coefficient (delta) cannot be retrieved due to no undesirable output (b variable) included in the model.")
+
+
+def assert_various_return_to_scale(rts):
+    if rts == RTS_CRS:
+        raise Exception(
+            "Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
 
 
 def assert_various_return_to_scale(rts):

--- a/pystoned/utils/tools.py
+++ b/pystoned/utils/tools.py
@@ -219,7 +219,7 @@ def assert_various_return_to_scale(rts):
             "Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
 
 
-def assert_various_return_to_scale(rts):
+def assert_various_return_to_scale_omega(rts):
     if rts == RTS_CRS:
         raise Exception(
-            "Estimated intercept (alpha) cannot be retrieved due to the constant returns-to-scale assumption.")
+            "Omega cannot be retrieved due to the constant returns-to-scale assumption.")


### PR DESCRIPTION
This pr provides:
* The fix for the checking of reference set of bad output in DEADDF.
* The assertion of vrs for omega in DEADUAL

## The fix for the checking of reference set of bad output in DEADDF.
* The checking of reference set of bad output including:
    * The consistent number of DMU with yref
For this reason, I prefer to remain the `assert_valid_reference_data_with_bad_outputs` module as last patch with fix, of course.
The DEADDF has been updated as DEA without `__reference` tag as a prettier construction.
```
from pystoned import DEA
from pystoned.constant import OPT_LOCAL, RTS_VRS
import numpy as np

x = np.array([[2, 1, 2, 3, 3, 4],[5, 2, 2, 2, 1, 1]])
x = x.T
y = np.array([1, 1, 1, 1, 1, 1])
y = y.T

xref = x
yref = y

# define and solve the DEA DDF model
model = DEA.DDF(y, x, b=None, gy=[0], gx=[1, 1], gb=None, rts=RTS_VRS, yref=yref, xref=xref, bref=None)
model.optimize(OPT_LOCAL)

# display the technical efficiency
model.display_theta()
```

## The assertion of vrs for omega in DEADUAL
```python3
import numpy as np
from pystoned import DEA
from pystoned.constant import OPT_LOCAL, RTS_CRS, ORIENT_IO

x = np.array([[10, 28, 30, 60],[12, 26, 16, 60], [13, 26, 15, 60]])
x = x.T
y = np.array([[5, 7, 10, 15], [6, 8, 9, 15], [7, 9, 10, 15]])
y = y.T

xref = np.array([[10, 28, 30, 60,20],[12, 26, 16, 60,20], [13, 26, 15, 60,20]])
xref = xref.T
yref = np.array([[5, 7, 10, 15,20], [6, 8, 9, 15,20], [7, 9, 10, 15,20]])
yref = yref.T

model = DEA.DUAL(y,x,rts = RTS_CRS,orient=ORIENT_IO,xref=xref, yref=yref)
model.optimize(OPT_LOCAL)

model.display_omega()
```

Thanks for your review!