### PR TITLE
fix: Add mosek into install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ install_requires = [
     'pandas>=1.1.3',
     'numpy>=1.19.2',
     'scipy>=1.5.2',
-    'matplotlib'
+    'matplotlib',
+    'mosek'
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because the `mosek` solver can be installed by `pip`, we should include the `mosek` in `setup.py`.
Since it can be installed automatically, we may reduce the documentation for installation of mosek:
https://pystoned.readthedocs.io/en/latest/install/index.html#solver

If the license is not installed, it'll prompt following information at `optimize` method:
```
Optimizing locally.
Estimating the additive model locally with mosek solver.
MOSEK error 1008: License cannot be located. The default search path is ':/home/user/mosek/mosek.lic:'.

*** A FLEXlm error occurred. FLEXlm reported:



*** end of FLEXlm report.

ERROR: rescode.err_missing_license_file(1008): License cannot be located. The
    default search path is ':/home/user/mosek/mosek.lic:'.
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    model.optimize(OPT_LOCAL)
  File "/home/user/dev/pyStoNED/pystoned/CNLS.py", line 86, in optimize
    self.problem_status, self.optimization_status = tools.optimize_model(
  File "/home/user/dev/pyStoNED/pystoned/utils/tools.py", line 37, in optimize_model
    return solver_instance.solve(model, tee=True), 1
  File "/usr/local/lib/python3.8/dist-packages/pyomo/solvers/plugins/solvers/direct_solver.py", line 128, in solve
    _status = self._apply_solver()
  File "/usr/local/lib/python3.8/dist-packages/pyomo/solvers/plugins/solvers/mosek_direct.py", line 175, in _apply_solver
    self._termcode = self._solver_model.optimize()
  File "/usr/local/lib/python3.8/dist-packages/Mosek-9.3.17-py3.8-linux-x86_64.egg/mosek/__init__.py", line 7627, in optimize
    raise Error(rescode(res),msg)
mosek.Error: rescode.err_missing_license_file(1008): License cannot be located. The default search path is ':/home/user/mosek/mosek.lic:'.
```

I'm not so sure if this message provides sufficient information for user,